### PR TITLE
Add function breadcumb_menu, fix product list layout

### DIFF
--- a/products/views.py
+++ b/products/views.py
@@ -25,7 +25,7 @@ def product_list_view(request): # 関数名を変更 (例: top_view, product_lis
     ).order_by('-created_at')
 
     # 検索結果を表示しない時用に変数の初期化
-    selected_category_for_breadcrumb = None
+    selected_category_for_breadcrumb_obj = None
 
     # 2. 検索フォームの処理
     search_form = ProductSearchForm(request.GET or None)
@@ -49,7 +49,7 @@ def product_list_view(request): # 関数名を変更 (例: top_view, product_lis
         if categories: # 何かカテゴリが選択されていれば
             queryset = queryset.filter(product_category__in=categories)
             if categories.exists(): # 選択されたカテゴリが1つ以上あれば
-                selected_category_for_breadcrumb = categories.first().name # 最初のカテゴリ名
+                selected_category_for_breadcrumb_obj = categories.first() # 最初のカテゴリオブジェクト
 
         # --- 価格帯絞り込み ---
         price_min = search_form.cleaned_data.get('price_min')
@@ -112,7 +112,7 @@ def product_list_view(request): # 関数名を変更 (例: top_view, product_lis
     context = {
         'products': products_on_page, # 現在のページの商品リスト
         'search_form': search_form,   # 絞り込み検索フォーム (後で追加)
-        'selected_category_for_breadcrumb': selected_category_for_breadcrumb, # パンクズリストのカテゴリ表示で使用
+        'selected_category_for_breadcrumb_obj': selected_category_for_breadcrumb_obj, # パンクズリストのカテゴリ表示で使用
     }
     return render(request, 'products/product_list.html', context)
 

--- a/templates/products/detail.html
+++ b/templates/products/detail.html
@@ -16,7 +16,11 @@
     <nav aria-label="breadcrumb"">
         <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="{% url 'products:top' %}" class="link-subtle">商品一覧</a></li>
-            <li class="breadcrumb-item"><a href="#" class="link-subtle">{{ product.product_category.name }}</a></li> {# TODO #}
+            {% if product.product_category %}
+                <li class="breadcrumb-item">
+                    <a href="{% url 'products:top' %}?category={{ product.product_category.pk }}" class="link-subtle">{{ product.product_category.name }}</a>
+                </li>
+            {% endif %}
             <li class="breadcrumb-item active" aria-current="page">{{ product.name|truncatechars:10 }}</li> {# 商品名を短縮表示 #}
         </ol>
     </nav>

--- a/templates/products/product_list.html
+++ b/templates/products/product_list.html
@@ -16,9 +16,10 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="{% url 'products:top' %}" class="link-subtle">商品一覧</a></li>
-            {% if selected_category_for_breadcrumb %}
-                <li class="breadcrumb-item">{{ selected_category_for_breadcrumb }}</li>
-                <li class="breadcrumb-item"><a href="#" class="link-subtle">{{ selected_category_for_breadcrumb }}</a></li>
+            {% if selected_category_for_breadcrumb_obj %}
+                <li class="breadcrumb-item active" aria-current="page"> {# ★ 最後の項目なので active に #}
+                    <a href="{% url 'products:top' %}?category={{ selected_category_for_breadcrumb_obj.pk }}" class="link-subtle">{{ selected_category_for_breadcrumb_obj.name }}</a>
+                </li>
             {% endif %}
         </ol>
     </nav>
@@ -130,6 +131,12 @@
 
         {# --- 右コンテンツエリア: 商品一覧 --- #}
         <main class="product-list-items">
+            {# --- キーワード検索の場合 --- #}
+            <div class="text-right">
+                {% if request.GET.keyword %}
+                    <span class="text-muted">キーワード:「{{ request.GET.keyword }}」の検索結果</span>
+                {% endif %}
+            </div>
             {% if products %}
             <div class="list-group mx-auto">
                 {% for product in products %}
@@ -180,6 +187,10 @@
                                                 </button>
                                             </form>
                                             {% endif %}
+                                        </div>
+                                        <div class="ms-2 text-right small text-muted">
+                                            <div class="text-muted">サイズ:{{ product.get_size_display }} </div>
+                                            <div class="text-muted">状態:{{ product.get_condition_display }}</div>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
・商品一覧、商品詳細ページのパンクズりすとリンクを生成
・キーワード検索の場合、その旨を表示
・商品一覧にサイズと状態を追加