### PR TITLE
Add error when send comment without input

### DIFF
--- a/interactions/forms.py
+++ b/interactions/forms.py
@@ -7,10 +7,11 @@ class CommentForm(forms.ModelForm):
         widget=forms.Textarea(
             attrs={
                 'class': 'form-control', 'rows': '3',
-                'placeholder': 'コメントを入力（任意）'
+                'placeholder': 'コメントを入力してください'
             }
         ),
-        required=False
+        required=True,
+        error_messages={'required': '未入力の場合、コメントは送信できません。'}
     )
 
     class Meta:

--- a/interactions/urls.py
+++ b/interactions/urls.py
@@ -4,7 +4,6 @@ from . import views
 app_name = 'interactions'
 
 urlpatterns = [
-    path('product/<int:product_pk>/comment/add/', views.add_comment, name='add_comment'),
     # お気に入り一覧ページ
     path('favorites/', views.favorite_list, name='favorite_list'),
     # お気に入り登録/解除


### PR DESCRIPTION
・未入力でコメント送信された場合に、エラーを表示するように修正
・エラーがあった場合に、エラー付きのフォームを表示するため、コメント登録の処理を、interactions/add_commentからproducts.detail内に移設